### PR TITLE
Custom exception class.

### DIFF
--- a/lib/cloudflare/connection.rb
+++ b/lib/cloudflare/connection.rb
@@ -6,8 +6,17 @@ require 'json'
 # - http://www.cloudflare.com/docs/host-api.html
 #
 module CloudFlare
+	class RequestError < StandardError
+		def initialize(what, response)
+			super(what)
+			
+			@response = response
+		end
+		
+		attr :response
+	end
+	
 	class Connection
-
 		# URL for Client and Host API
 		URL_API = {
 			client: 'https://www.cloudflare.com/api_json.html',
@@ -514,10 +523,11 @@ module CloudFlare
 			res = http.request(req)
 			out = JSON.parse(res.body)
 
+			# If there is an error, raise an exception:
 			if out['result'] == 'error'
-				raise out['msg']
+				raise RequestError.new(out['msg'], out)
 			else
-				out
+				return out
 			end
 		end
 	end

--- a/test/test_cloudflare.rb
+++ b/test/test_cloudflare.rb
@@ -2,23 +2,23 @@ require 'test/unit'
 require 'cloudflare'
 
 class HostTest < Test::Unit::TestCase
-  def test_client_connection
-    cf = CloudFlare::connection('example_api', 'example@example.com')
+	def test_client_connection
+		cf = CloudFlare::connection('example_api', 'example@example.com')
 		
-		info = assert_raise RuntimeError, "as" do
-		 	cf.ipv46('example.com', true)
+		info = assert_raise CloudFlare::RequestError, "as" do
+			cf.ipv46('example.com', true)
 		end
 
 		assert info, 'No or invalid host_key.'
-  end
+	end
 
-  def test_host_connection
-    cf = CloudFlare::connection('example_api')
+	def test_host_connection
+		cf = CloudFlare::connection('example_api')
 
-    info = assert_raise RuntimeError do 
+		info = assert_raise CloudFlare::RequestError do 
 			cf.user_auth('example.com', 'password')
 		end
 
 		assert info, 'No or invalid host_key.'
-  end
+	end
 end


### PR DESCRIPTION
Raising a string with no wrapper class is probably considered confusing and bad practice. Fixed it with a custom `class RequestError`.
