### PR TITLE
Fix CloudFlare.connection to pass in email address

### DIFF
--- a/lib/cloudflare.rb
+++ b/lib/cloudflare.rb
@@ -22,6 +22,6 @@ require 'cloudflare/connection'
 
 module CloudFlare
 	def self.connection(api_key, email = nil)
-		Connection.new(api_key, email = nil)
+		Connection.new(api_key, email)
 	end
 end


### PR DESCRIPTION
CloudFlare.connection would nil out the email address, even if
it was passed in. This commit fixes that behavior.
