### PR TITLE
Add logs to a cloudflare zone

### DIFF
--- a/lib/cloudflare/connection.rb
+++ b/lib/cloudflare/connection.rb
@@ -51,6 +51,7 @@ module Cloudflare
 
 			# Convert HTTP API responses to our own internal response class:
 			super(url, headers: headers, accept: 'application/json', **options) do |response|
+				options[:response] = response
 				Response.new(response.request.url, response.body, **options)
 			end
 		end

--- a/lib/cloudflare/connection.rb
+++ b/lib/cloudflare/connection.rb
@@ -51,7 +51,7 @@ module Cloudflare
 
 			# Convert HTTP API responses to our own internal response class:
 			super(url, headers: headers, accept: 'application/json', **options) do |response|
-				Response.new(response.request.url, response.body)
+				Response.new(response.request.url, response.body, **options)
 			end
 		end
 

--- a/lib/cloudflare/response.rb
+++ b/lib/cloudflare/response.rb
@@ -35,10 +35,22 @@ module Cloudflare
 	end
 
 	class Response
-		def initialize(what, content)
+		def initialize(what, content, **options)
 			@what = what
 
-			@body = JSON.parse(content, symbolize_names: true)
+			if options[:headers]["Content-Type"].eql? "application/json"
+				@body = JSON.parse(content, symbolize_names: true)
+			else
+				begin
+					@body = {}
+					@body[:result] = content.lines
+					@body[:success] = true
+				rescue Exception => e
+					@body = {}
+					@body[:success] = false
+					@body[:errors] = e.to_s
+				end
+			end
 		end
 
 		attr_reader :body

--- a/lib/cloudflare/response.rb
+++ b/lib/cloudflare/response.rb
@@ -37,20 +37,24 @@ module Cloudflare
 	class Response
 		def initialize(what, content, **options)
 			@what = what
-
-			if options[:headers]["Content-Type"].eql? "application/json"
-				@body = JSON.parse(content, symbolize_names: true)
-			else
-				begin
-					@body = {}
-					@body[:result] = content.lines
-					@body[:success] = true
-				rescue Exception => e
-					@body = {}
-					@body[:success] = false
-					@body[:errors] = e.to_s
+			@body = {}
+			if (200..299).include?(options[:response].code)
+				if options[:headers]["Content-Type"].eql? "application/json"
+					@body = JSON.parse(content, symbolize_names: true)
+				else
+					begin
+						@body[:result] = content.lines
+						@body[:success] = true
+					rescue Exception => e
+						@body[:success] = false
+						@body[:errors] = e.to_s
+					end
 				end
+			else
+				@body[:success] = false
+				@body[:errors] = [options[:response].description]
 			end
+
 		end
 
 		attr_reader :body


### PR DESCRIPTION
Hi,

I needed to add the logs functionality, so that we can get them from CloudFlare and store them in our premises.

I did this commit, which has a (important) caveat grearding the result.
The [cloudflare doc](https://support.cloudflare.com/hc/en-us/articles/216672448-Enterprise-Log-Share-Logpull-REST-API) states that they do not, for the logs, send back one JSON, but many lines of JSON, so basically something of the like:

```
{"ClientIP":"1.2.3.4","ClientRequestHost":"fqdn.domain.name","ClientRequestMethod":"GET","ClientRequestURI":"/file1.png"}
{"ClientIP":"2.3.4.5","ClientRequestHost":"fqdn.domain.name","ClientRequestMethod":"GET","ClientRequestURI":"/file1.png"}
{"ClientIP":"4.5.6.7","ClientRequestHost":"fqdn.domain.name","ClientRequestMethod":"GET","ClientRequestURI":"/other_file.png"}

```

As you can see, each line is a valid JSON, but the result itself is not. So what I did was adding options so that we can force text/plain instead of application/json, and in those case stop the parsing and split it instead. The JSON parsing is then done by the Logs class, as it should. But if we get an error from CloudFlare, I do not know how I can figure it out. Given that in the connection.rb file, you set (in the initializer)

```
			# Convert HTTP API responses to our own internal response class:
			super(url, headers: headers, accept: 'application/json', **options) do |response|
				Response.new(response.request.url, response.body, **options)
			end
```

Because of this, the response.code (which would help) is not accessible. But changing the Response initializer signature is IMO an important change. I'm uncertain on which way would be best to continue, so your input is very welcom.
