### PR TITLE
Fix infinity loop when record number % page_size = 0

### DIFF
--- a/lib/cloudflare/connection.rb
+++ b/lib/cloudflare/connection.rb
@@ -66,7 +66,7 @@ module Cloudflare
 				rules = obj.new(concat_urls(url, "?#{query}#{url_args}"), self, **options)
 				page_results = rules.get.results
 				results += page_results
-				break if page_results.empty? || page_results.size % page_size != 0
+				break if page_results.size < page_size
 				page += 1
 			end
 			results

--- a/lib/cloudflare/connection.rb
+++ b/lib/cloudflare/connection.rb
@@ -64,8 +64,9 @@ module Cloudflare
 			loop do
 				query = URI.encode_www_form scope_type: :organization, per_page: page_size, page: page
 				rules = obj.new(concat_urls(url, "?#{query}#{url_args}"), self, **options)
-				results += rules.get.results
-				break if results.empty? || results.size % page_size != 0
+				page_results = rules.get.results
+				results += page_results
+				break if page_results.empty? || page_results.size % page_size != 0
 				page += 1
 			end
 			results


### PR DESCRIPTION
`paginate` goes into infinite loop if total records number % page_size = 0 (for example, 50).
