### PR TITLE
Support for the custom hostnames endpoint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,5 @@ matrix:
 
 env:
   global:
+    CLOUDFLARE_TEST_ZONE_MANAGEMENT: 'true'
     secure: c5yG7N1r9nYuw47Y90jGeoHNvkL59AAC55dtPAhKP+gjXWW8hKbntj3oj+lVkxEqzRpzEQgYZzUElrP+6mJnb20ldclZg03L56243tMtVEcpGOx/MFhnIBkx3kKu1H6ydKKMxieHxjsLQ3vnpcIZ3p0skTQjYbjdu607tjbyg7s=

--- a/lib/cloudflare/accounts.rb
+++ b/lib/cloudflare/accounts.rb
@@ -37,9 +37,7 @@ module Cloudflare
 		end
 
 		def create(name)
-			response = self.post(name: name)
-
-			represent(response.headers, response.read)
+			represent_message(self.post(name: name))
 		end
 
 	end

--- a/lib/cloudflare/accounts.rb
+++ b/lib/cloudflare/accounts.rb
@@ -28,24 +28,19 @@ require_relative 'paginate'
 module Cloudflare
 	class Account < Representation
 	end
-	
+
 	class Accounts < Representation
 		include Paginate
-		
-		def represent(metadata, attributes)
-			resource = @resource.with(path: attributes[:id])
-			
-			return Account.new(resource, metadata: metadata, value: attributes)
+
+		def representation
+			Account
 		end
-		
+
 		def create(name)
 			response = self.post(name: name)
-			
-			return represent(response.headers, response.read)
+
+			represent(response.headers, response.read)
 		end
-		
-		def find_by_id(id)
-			Zone.new(@resource.with(path: id))
-		end
+
 	end
 end

--- a/lib/cloudflare/custom_hostname/ssl_attribute.rb
+++ b/lib/cloudflare/custom_hostname/ssl_attribute.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require_relative './ssl_attribute/settings'
+
+module Cloudflare
+
+  class CustomHostname < Representation
+
+    class SSLAttribute
+
+      def initialize(params)
+        @params = params
+      end
+
+      def active?
+        status == 'active'
+      end
+
+      def cname
+        @params[:cname]
+      end
+
+      def cname_target
+        @params[:cname_target]
+      end
+
+      def http_body
+        @params[:http_body]
+      end
+
+      def http_url
+        @params[:http_url]
+      end
+
+      def method
+        @params[:method]
+      end
+
+      def pending_validation?
+        status == 'pending_validation'
+      end
+
+      # Wraps the settings hash if it exists or initializes the settings hash and then wraps it
+      def settings
+        @settings ||= Settings.new(@params[:settings] ||= {})
+      end
+
+      def status
+        @params[:status]
+      end
+
+      def to_h
+        @params
+      end
+
+      def type
+        @params[:type]
+      end
+
+      def validation_errors
+        @params[:validation_errors]
+      end
+
+    end
+
+  end
+
+end

--- a/lib/cloudflare/custom_hostname/ssl_attribute/settings.rb
+++ b/lib/cloudflare/custom_hostname/ssl_attribute/settings.rb
@@ -4,9 +4,9 @@ module Cloudflare
 
   class CustomHostname < Representation
 
-    class SSLParams
+    class SSLAttribute
 
-      class SSLSettings
+      class Settings
 
         def initialize(settings)
           @settings = settings
@@ -71,54 +71,6 @@ module Cloudflare
         end
 
       end
-
-      def initialize(params)
-        @params = params
-      end
-
-      def active?
-        status == 'active'
-      end
-
-      def cname
-        @params[:cname]
-      end
-
-      def cname_target
-        @params[:cname_target]
-      end
-
-      def http_body
-        @params[:http_body]
-      end
-
-      def http_url
-        @params[:http_url]
-      end
-
-      def method
-        @params[:method]
-      end
-
-      # Wraps the settings hash if it exists or initializes the settings hash and then wraps it
-      def settings
-        @settings ||= SSLSettings.new(@params[:settings] ||= {})
-      end
-
-      def status
-        @params[:status]
-      end
-
-      def to_h
-        @params
-      end
-
-      def validation_errors
-        @params[:validation_errors]
-      end
-
     end
-
   end
-
 end

--- a/lib/cloudflare/custom_hostname/ssl_params.rb
+++ b/lib/cloudflare/custom_hostname/ssl_params.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+module Cloudflare
+
+  class CustomHostname < Representation
+
+    class SSLParams
+
+      class SSLSettings
+
+        def initialize(settings)
+          @settings = settings
+        end
+
+        def ciphers
+          @settings[:ciphers]
+        end
+
+        def ciphers=(value)
+          @settings[:ciphers] = value
+        end
+
+        # This will return the raw value, it is needed because
+        # if a value is nil we can't assume that it means it is off
+        def http2
+          @settings[:http2]
+        end
+
+        # Always coerce into a boolean, if the key is not
+        # provided, this value may not be accurate
+        def http2?
+          http2 == 'on'
+        end
+
+        def http2=(value)
+          process_boolean(:http2, value)
+        end
+
+        def min_tls_version
+          @settings[:min_tls_version]
+        end
+
+        def min_tls_version=(value)
+          @settings[:min_tls_version] = value
+        end
+
+        # This will return the raw value, it is needed because
+        # if a value is nil we can't assume that it means it is off
+        def tls_1_3
+          @settings[:tls_1_3]
+        end
+
+        # Always coerce into a boolean, if the key is not
+        # provided, this value may not be accurate
+        def tls_1_3?
+          tls_1_3 == 'on'
+        end
+
+        def tls_1_3=(value)
+          process_boolean(:tls_1_3, value)
+        end
+
+        private
+
+        def process_boolean(key, value)
+          if value.nil?
+            @settings.delete(key)
+          else
+            @settings[key] = !value || value == 'off' ? 'off' : 'on'
+          end
+        end
+
+      end
+
+      def initialize(params)
+        @params = params
+      end
+
+      def active?
+        status == 'active'
+      end
+
+      def cname
+        @params[:cname]
+      end
+
+      def cname_target
+        @params[:cname_target]
+      end
+
+      def http_body
+        @params[:http_body]
+      end
+
+      def http_url
+        @params[:http_url]
+      end
+
+      def method
+        @params[:method]
+      end
+
+      # Wraps the settings hash if it exists or initializes the settings hash and then wraps it
+      def settings
+        @settings ||= SSLSettings.new(@params[:settings] ||= {})
+      end
+
+      def status
+        @params[:status]
+      end
+
+      def to_h
+        @params
+      end
+
+      def validation_errors
+        @params[:validation_errors]
+      end
+
+    end
+
+  end
+
+end

--- a/lib/cloudflare/custom_hostnames.rb
+++ b/lib/cloudflare/custom_hostnames.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require_relative 'custom_hostname/ssl_params'
+require_relative 'paginate'
+require_relative 'representation'
+
+module Cloudflare
+
+  class CustomHostname < Representation
+
+    # Only available if enabled for your zone
+    def custom_origin
+      value[:custom_origin_server]
+    end
+
+    # Only available if enabled for your zone
+    def custom_metadata
+      value[:custom_metadata]
+    end
+
+    def hostname
+      value[:hostname]
+    end
+
+    def ssl
+      @ssl ||= SSLParams.new(value[:ssl])
+    end
+
+    def update_settings(metadata: nil, origin: nil, ssl_settings: nil)
+      attrs = { ssl: ssl.to_h }
+      attrs[:ssl][:settings].merge!(ssl_settings) if ssl_settings
+      attrs[:custom_metadata] = metadata if metadata
+      attrs[:custom_origin_server] = origin if origin
+
+      response = patch(attrs)
+
+      @ssl = nil # Kill off our cached version of the ssl object so it will be regenerated from the response
+      @value = response.result
+    end
+
+    alias :to_s :hostname
+
+  end
+
+  class CustomHostnames < Representation
+    include Paginate
+
+    def representation
+      CustomHostname
+    end
+
+    # initializes a custom hostname object and yields it for customization before saving
+    def create(hostname, metadata: nil, origin: nil, ssl: {}, &block)
+      attrs = { hostname: hostname, ssl: { method: 'http', type: 'dv' }.merge(ssl) }
+      attrs[:custom_metadata] = metadata if metadata
+      attrs[:custom_origin_server] = origin if origin
+
+      message = self.post(attrs)
+      represent(message.headers, message.result)
+    end
+
+    def find_by_hostname(hostname)
+      each(hostname: hostname).first
+    end
+
+    def find_by_ssl_state(enabled: true)
+      each(ssl: enabled ? 1 : 0).first
+    end
+
+  end
+
+end

--- a/lib/cloudflare/custom_hostnames.rb
+++ b/lib/cloudflare/custom_hostnames.rb
@@ -72,8 +72,7 @@ module Cloudflare
       attrs[:custom_metadata] = metadata if metadata
       attrs[:custom_origin_server] = origin if origin
 
-      message = self.post(attrs)
-      represent(message.headers, message.result)
+      represent_message(self.post(attrs))
     end
 
     def find_by_hostname(hostname)

--- a/lib/cloudflare/custom_hostnames.rb
+++ b/lib/cloudflare/custom_hostnames.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+# This implements the Custom Hostname API
+# https://api.cloudflare.com/#custom-hostname-for-a-zone-properties
+
 require_relative 'custom_hostname/ssl_attribute'
 require_relative 'paginate'
 require_relative 'representation'

--- a/lib/cloudflare/dns.rb
+++ b/lib/cloudflare/dns.rb
@@ -40,22 +40,22 @@ module Cloudflare
 					name: @record[:name],
 					content: content
 				)
-				
+
 				@value = response.result
 			end
-			
+
 			def type
 				value[:type]
 			end
-			
+
 			def name
 				value[:name]
 			end
-			
+
 			def content
 				value[:content]
 			end
-			
+
 			def to_s
 				"#{@record[:name]} #{@record[:type]} #{@record[:content]}"
 			end
@@ -63,19 +63,17 @@ module Cloudflare
 
 		class Records < Representation
 			include Paginate
-			
+
 			def representation
 				Record
 			end
-			
+
 			TTL_AUTO = 1
 			
 			def create(type, name, content, **options)
-				message = self.post(type: type, name: name, content: content, **options)
-
-				represent(message.headers, message.result)
+				represent_message(self.post(type: type, name: name, content: content, **options))
 			end
-			
+
 			def find_by_name(name)
 				each(name: name).first
 			end

--- a/lib/cloudflare/dns.rb
+++ b/lib/cloudflare/dns.rb
@@ -72,19 +72,12 @@ module Cloudflare
 			
 			def create(type, name, content, **options)
 				message = self.post(type: type, name: name, content: content, **options)
-				
-				id = message.result[:id]
-				resource = @resource.with(path: id)
-				
-				return representation.new(resource, metadata: message.headers, value: message.result)
+
+				represent(message.headers, message.result)
 			end
 			
 			def find_by_name(name)
 				each(name: name).first
-			end
-			
-			def find_by_id(id)
-				Record.new(@resource.with(path: id))
 			end
 		end
 	end

--- a/lib/cloudflare/firewall.rb
+++ b/lib/cloudflare/firewall.rb
@@ -62,7 +62,7 @@ module Cloudflare
 					}
 				})
 
-				represent(message.headers, message.result)
+				represent_message(message)
 			end
 
 			def each_by_value(value, &block)

--- a/lib/cloudflare/firewall.rb
+++ b/lib/cloudflare/firewall.rb
@@ -29,15 +29,15 @@ module Cloudflare
 			def mode
 				value[:mode]
 			end
-			
+
 			def notes
 				value[:notes]
 			end
-			
+
 			def configuration
 				value[:configuration]
 			end
-			
+
 			def to_s
 				"#{configuration[:value]} - #{mode} - #{notes}"
 			end
@@ -45,14 +45,14 @@ module Cloudflare
 
 		class Rules < Representation
 			include Paginate
-			
+
 			def representation
 				Rule
 			end
-			
+
 			def set(mode, value, notes: nil, target: 'ip')
 				notes ||= "cloudflare gem [#{mode}] #{Time.now.strftime('%m/%d/%y')}"
-				
+
 				message = self.post({
 					mode: mode.to_s,
 					notes: notes,
@@ -61,17 +61,10 @@ module Cloudflare
 						value: value.to_s,
 					}
 				})
-				
-				id = message.result[:id]
-				resource = @resource.with(path: id)
-				
-				return representation.new(resource, metadata: message.headers, value: message.result)
+
+				represent(message.headers, message.result)
 			end
-			
-			def find_by_id(id)
-				Rule.new(@resource.with(path: id))
-			end
-			
+
 			def each_by_value(value, &block)
 				each(configuration_value: value, &block)
 			end

--- a/lib/cloudflare/paginate.rb
+++ b/lib/cloudflare/paginate.rb
@@ -1,15 +1,15 @@
 # Copyright, 2018, by Samuel G. D. Williams. <http://www.codeotaku.com>
-# 
+#
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
 # in the Software without restriction, including without limitation the rights
 # to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 # copies of the Software, and to permit persons to whom the Software is
 # furnished to do so, subject to the following conditions:
-# 
+#
 # The above copyright notice and this permission notice shall be included in
 # all copies or substantial portions of the Software.
-# 
+#
 # THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 # IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 # FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -21,34 +21,34 @@
 module Cloudflare
 	module Paginate
 		include Enumerable
-		
-		def empty?
-			self.value.empty?
-		end
-		
-		def representation
-			Representation
-		end
-		
+
 		def each(page: 1, per_page: 50, **parameters)
 			return to_enum(:each, page: page, per_page: per_page, **parameters) unless block_given?
-			
+
 			while true
 				zones = @resource.get(self.class, page: page, per_page: per_page, **parameters)
-				
+
 				break if zones.empty?
-				
+
 				Array(zones.value).each do |attributes|
 					resource = @resource.with(path: attributes[:id])
-					
+
 					yield representation.new(resource, metadata: zones.metadata, value: attributes)
 				end
-				
+
 				page += 1
-				
+
 				# Was this the last page?
 				break if zones.value.count < per_page
 			end
+		end
+
+		def empty?
+			self.value.empty?
+		end
+
+		def find_by_id(id)
+			representation.new(@resource.with(path: id))
 		end
 	end
 end

--- a/lib/cloudflare/paginate.rb
+++ b/lib/cloudflare/paginate.rb
@@ -31,9 +31,7 @@ module Cloudflare
 				break if zones.empty?
 
 				Array(zones.value).each do |attributes|
-					resource = @resource.with(path: attributes[:id])
-
-					yield representation.new(resource, metadata: zones.metadata, value: attributes)
+					yield represent(zones.metadata, attributes)
 				end
 
 				page += 1

--- a/lib/cloudflare/representation.rb
+++ b/lib/cloudflare/representation.rb
@@ -84,7 +84,17 @@ module Cloudflare
 			
 			return message
 		end
-		
+
+		def representation
+			Representation
+		end
+
+		def represent(metadata, attributes)
+			resource = @resource.with(path: attributes[:id])
+
+			representation.new(resource, metadata: metadata, value: attributes)
+		end
+
 		def to_hash
 			if value.is_a?(Hash)
 				return value

--- a/lib/cloudflare/representation.rb
+++ b/lib/cloudflare/representation.rb
@@ -95,6 +95,10 @@ module Cloudflare
 			representation.new(resource, metadata: metadata, value: attributes)
 		end
 
+		def represent_message(message)
+			represent(message.headers, message.result)
+		end
+
 		def to_hash
 			if value.is_a?(Hash)
 				return value

--- a/lib/cloudflare/zones.rb
+++ b/lib/cloudflare/zones.rb
@@ -69,19 +69,12 @@ module Cloudflare
 		
 		def create(name, account, jump_start = false)
 			message = self.post(name: name, account: account.to_hash, jump_start: jump_start)
-			
-			id = message.result[:id]
-			resource = @resource.with(path: id)
-			
-			return representation.new(resource, metadata: message.headers, value: message.result)
-		end
-		
-		def find_by_name(name)
-			each(name: name).first
+
+			represent(message.headers,message.result)
 		end
 
-		def find_by_id(id)
-			Zone.new(@resource.with(path: id))
+		def find_by_name(name)
+			each(name: name).first
 		end
 	end
 end

--- a/lib/cloudflare/zones.rb
+++ b/lib/cloudflare/zones.rb
@@ -25,12 +25,17 @@
 require_relative 'representation'
 require_relative 'paginate'
 
+require_relative 'custom_hostnames'
 require_relative 'firewall'
 require_relative 'dns'
 require_relative 'logs'
 
 module Cloudflare
 	class Zone < Representation
+		def custom_hostnames
+			CustomHostnames.new(@resource.with(path: 'custom_hostnames'))
+		end
+
 		def dns_records
 			DNS::Records.new(@resource.with(path: 'dns_records'))
 		end

--- a/lib/cloudflare/zones.rb
+++ b/lib/cloudflare/zones.rb
@@ -71,11 +71,9 @@ module Cloudflare
 		def representation
 			Zone
 		end
-		
-		def create(name, account, jump_start = false)
-			message = self.post(name: name, account: account.to_hash, jump_start: jump_start)
 
-			represent(message.headers,message.result)
+		def create(name, account, jump_start = false)
+			represent_message(self.post(name: name, account: account.to_hash, jump_start: jump_start))
 		end
 
 		def find_by_name(name)

--- a/spec/cloudflare/custom_hostname/ssl_attribute/settings_spec.rb
+++ b/spec/cloudflare/custom_hostname/ssl_attribute/settings_spec.rb
@@ -1,0 +1,54 @@
+RSpec.describe Cloudflare::CustomHostname::SSLAttribute::Settings do
+
+  subject { described_class.new({}) }
+
+  it 'has an accessor for ciphers' do
+    ciphers = double
+    expect(subject.ciphers).to be_nil
+    subject.ciphers = ciphers
+    expect(subject.ciphers).to be ciphers
+  end
+
+  it 'has a boolean accessor for http2' do
+    expect(subject.http2).to be_nil
+    expect(subject.http2?).to be false
+    subject.http2 = true
+    expect(subject.http2).to eq 'on'
+    expect(subject.http2?).to be true
+    subject.http2 = false
+    expect(subject.http2).to eq 'off'
+    expect(subject.http2?).to be false
+    subject.http2 = 'on'
+    expect(subject.http2).to eq 'on'
+    expect(subject.http2?).to be true
+    subject.http2 = 'off'
+    expect(subject.http2).to eq 'off'
+    expect(subject.http2?).to be false
+  end
+
+  it 'has an accessor for min_tls_version' do
+    tls_version = double
+    expect(subject.min_tls_version).to be_nil
+    subject.min_tls_version = tls_version
+    expect(subject.min_tls_version).to be tls_version
+  end
+
+  it 'has a boolean accessor for tls_1_3' do
+    expect(subject.tls_1_3).to be_nil
+    expect(subject.tls_1_3?).to be false
+    subject.tls_1_3 = true
+    expect(subject.tls_1_3).to eq 'on'
+    expect(subject.tls_1_3?).to be true
+    subject.tls_1_3 = false
+    expect(subject.tls_1_3).to eq 'off'
+    expect(subject.tls_1_3?).to be false
+    subject.tls_1_3 = 'on'
+    expect(subject.tls_1_3).to eq 'on'
+    expect(subject.tls_1_3?).to be true
+    subject.tls_1_3 = 'off'
+    expect(subject.tls_1_3).to eq 'off'
+    expect(subject.tls_1_3?).to be false
+  end
+
+
+end

--- a/spec/cloudflare/custom_hostname/ssl_attribute_spec.rb
+++ b/spec/cloudflare/custom_hostname/ssl_attribute_spec.rb
@@ -1,0 +1,73 @@
+RSpec.describe Cloudflare::CustomHostname::SSLAttribute do
+
+  accessors = [:cname, :cname_target, :http_body, :http_url, :method, :status, :type, :validation_errors]
+
+  let(:original_hash) { {} }
+
+  subject { described_class.new(original_hash) }
+
+  accessors.each do |key|
+
+    it "has an accessor for the #{key} value" do
+      test_value = double
+      expect(subject.send(key)).to be_nil
+      original_hash[key] = test_value
+      expect(subject.send(key)).to be test_value
+    end
+
+  end
+
+  it '#active? returns true when the status is "active" and false otherwise' do
+    expect(subject.active?).to be false
+    original_hash[:status] = 'initializing'
+    expect(subject.active?).to be false
+    original_hash[:status] = 'pending_validation'
+    expect(subject.active?).to be false
+    original_hash[:status] = 'pending_deployment'
+    expect(subject.active?).to be false
+    original_hash[:status] = 'active'
+    expect(subject.active?).to be true
+  end
+
+  it '#pending_validation? returns true when the status is "pending_validation" and false otherwise' do
+    expect(subject.pending_validation?).to be false
+    original_hash[:status] = 'initializing'
+    expect(subject.pending_validation?).to be false
+    original_hash[:status] = 'active'
+    expect(subject.pending_validation?).to be false
+    original_hash[:status] = 'pending_deployment'
+    expect(subject.pending_validation?).to be false
+    original_hash[:status] = 'pending_validation'
+    expect(subject.pending_validation?).to be true
+  end
+
+  describe '#settings' do
+
+    it 'should return a Settings object' do
+      expect(subject.settings).to be_kind_of Cloudflare::CustomHostname::SSLAttribute::Settings
+    end
+
+    it 'initailizes the settings object with the value from the settings key' do
+      settings = { min_tls_version: double }
+      original_hash[:settings] = settings
+      expect(subject.settings.min_tls_version).to be settings[:min_tls_version]
+    end
+
+    it 'initializes the settings object with a new hash if the settings key does not exist' do
+      expected_value = double
+      expect(original_hash[:settings]).to be_nil
+      expect(subject.settings.min_tls_version).to be_nil
+      expect(original_hash[:settings]).not_to be_nil
+      original_hash[:settings][:min_tls_version] = expected_value
+      expect(subject.settings.min_tls_version).to be expected_value
+    end
+
+    it 'updates the stored hash with values set on the settings object' do
+      expected_value = double
+      expect(subject.settings.min_tls_version).to be_nil
+      subject.settings.min_tls_version = expected_value
+      expect(original_hash[:settings][:min_tls_version]).to be expected_value
+    end
+  end
+
+end

--- a/spec/cloudflare/custom_hostnames_spec.rb
+++ b/spec/cloudflare/custom_hostnames_spec.rb
@@ -1,0 +1,195 @@
+
+RSpec.describe Cloudflare::CustomHostnames, order: :defined, timeout: 30 do
+	include_context Cloudflare::Zone
+
+	let(:domain) { "www#{ENV['TRAVIS_JOB_ID'] || rand(1..5)}.ourtest.com" }
+
+	let(:record) { @record = zone.custom_hostnames.create(domain) }
+
+	let(:custom_origin) do
+		subdomain = "origin-#{rand(1..10)}"
+		@dns_record = zone.dns_records.create("A", subdomain, "1.2.3.4") # This needs to exist or the calls will fail
+		"#{subdomain}.#{zone.name}"
+	end
+
+	after do
+		if defined? @record
+			expect(@record.delete).to be_success
+		end
+
+		if defined? @dns_record
+			expect(@dns_record.delete).to be_success
+		end
+	end
+
+	it 'can create a custom hostname record' do
+    expect(record).to be_kind_of Cloudflare::CustomHostname
+		expect(record.custom_metadata).to be_nil
+		expect(record.hostname).to eq domain
+		expect(record.custom_origin).to be_nil
+		expect(record.ssl.method).to eq 'http'
+		expect(record.ssl.type).to eq 'dv'
+	end
+
+	it 'can create a custom hostname record with a custom origin' do
+		@record = zone.custom_hostnames.create(domain, origin: custom_origin)
+
+		expect(@record).to be_kind_of Cloudflare::CustomHostname
+		expect(@record.custom_metadata).to be_nil
+		expect(@record.hostname).to eq domain
+		expect(@record.custom_origin).to eq custom_origin
+		expect(@record.ssl.method).to eq 'http'
+		expect(@record.ssl.type).to eq 'dv'
+	end
+
+	it 'can create a custom hostname record with different ssl options' do
+		@record = zone.custom_hostnames.create(domain, ssl: { method: 'cname' })
+
+		expect(@record).to be_kind_of Cloudflare::CustomHostname
+		expect(@record.custom_metadata).to be_nil
+		expect(@record.hostname).to eq domain
+		expect(@record.custom_origin).to be_nil
+		expect(@record.ssl.method).to eq 'cname'
+		expect(@record.ssl.type).to eq 'dv'
+	end
+
+	it 'can create a custom hostname record with additional metadata' do
+		metadata = { a: rand(1..10) }
+
+		begin
+			@record = zone.custom_hostnames.create(domain, metadata: metadata)
+
+			expect(@record).to be_kind_of Cloudflare::CustomHostname
+			expect(@record.custom_metadata).to eq metadata
+			expect(@record.hostname).to eq domain
+			expect(@record.custom_origin).to be_nil
+			expect(@record.ssl.method).to eq 'http'
+			expect(@record.ssl.type).to eq 'dv'
+		rescue Cloudflare::RequestError => e
+			if e.message.include?('No custom metadata access has been allocated for this zone')
+				skip(e.message) # This currently doesn't work but might start eventually: https://github.com/socketry/async-rspec/issues/7
+			else
+				raise
+			end
+		end
+	end
+
+	it 'can look up an existing custom hostname by the hostname or id' do
+		expect(zone.custom_hostnames.find_by_hostname(record.hostname).id).to eq record.id
+		expect(zone.custom_hostnames.find_by_id(record.id).id).to eq record.id
+	end
+
+	context 'with existing record' do
+
+		it 'returns the hostname when calling #to_s' do
+			expect(record.to_s).to eq domain
+		end
+
+		it 'can update metadata' do
+			metadata = { c: rand(1..10) }
+
+			expect(record.custom_metadata).to be_nil
+
+			begin
+				record.update_settings(metadata: metadata)
+
+				# Make sure the existing object is updated
+				expect(record.custom_metadata).to eq metadata
+
+				# Verify that the server has the changes
+				found_record = zone.custom_hostnames.find_by_id(record.id)
+
+				expect(found_record.custom_metadata).to eq metadata
+				expect(found_record.hostname).to eq domain
+				expect(found_record.custom_origin).to be_nil
+			rescue Cloudflare::RequestError => e
+				if e.message.include?('No custom metadata access has been allocated for this zone')
+					skip(e.message) # This currently doesn't work but might start eventually: https://github.com/socketry/async-rspec/issues/7
+				else
+					raise
+				end
+			end
+		end
+
+		it 'can update the custom origin' do
+			expect(record.custom_origin).to be_nil
+
+			record.update_settings(origin: custom_origin)
+
+			# Make sure the existing object is updated
+			expect(record.custom_origin).to eq custom_origin
+
+			# Verify that the server has the changes
+			found_record = zone.custom_hostnames.find_by_id(record.id)
+
+			expect(found_record.custom_metadata).to be_nil
+			expect(found_record.hostname).to eq domain
+			expect(found_record.custom_origin).to eq custom_origin
+		end
+
+		it 'can update ssl information' do
+				expect(record.ssl.method).to eq 'http'
+
+				record.update_settings(ssl: { method: 'cname', type: 'dv' })
+
+				# Make sure the existing object is updated
+				expect(record.ssl.method).to eq 'cname'
+
+				# Verify that the server has the changes
+				found_record = zone.custom_hostnames.find_by_id(record.id)
+
+				expect(found_record.custom_metadata).to be_nil
+				expect(found_record.hostname).to eq domain
+				expect(found_record.custom_origin).to be_nil
+				expect(found_record.ssl.method).to eq 'cname'
+		end
+
+		context 'has an ssl section' do
+
+			it 'wraps it in an SSLAttributes object' do
+				expect(record.ssl).to be_kind_of Cloudflare::CustomHostname::SSLAttribute
+			end
+
+			it 'has some helpers for commonly used keys' do
+				# Make sure our values exist before we check to make sure that they are returned correctly
+				expect(record.value[:ssl].values_at(:method, :http_body, :http_url).compact).not_to be_empty
+				expect(record.ssl.method).to be record.value[:ssl][:method]
+				expect(record.ssl.http_body).to be record.value[:ssl][:http_body]
+				expect(record.ssl.http_url).to be record.value[:ssl][:http_url]
+			end
+
+		end
+
+		describe '#ssl_active?' do
+
+			it 'returns the result of calling ssl.active?' do
+				expected_value = double
+				expect(record.ssl).to receive(:active?).and_return(expected_value)
+				expect(record).not_to receive(:send_patch)
+				expect(record.ssl_active?).to be expected_value
+			end
+
+			it 'returns the result of calling ssl.active? without triggering an update if force_update is true and the ssl is not in the pending_validation state' do
+				expected_value = double
+				expect(record.ssl).to receive(:active?).and_return(expected_value)
+				expect(record.ssl.method).not_to be_nil
+				expect(record.ssl.type).not_to be_nil
+				expect(record.ssl.pending_validation?).to be false
+				expect(record).not_to receive(:send_patch).with(ssl: { method: record.ssl.method, type: record.ssl.type })
+				expect(record.ssl_active?(true)).to be expected_value
+			end
+
+			it 'returns the result of calling ssl.active? after triggering an update if force_update is true and the ssl is in the pending_validation state' do
+				expected_value = double
+				expect(record.ssl).to receive(:active?).and_return(expected_value)
+				expect(record.ssl.method).not_to be_nil
+				expect(record.ssl.type).not_to be_nil
+				record.value[:ssl][:status] = 'pending_validation'
+				expect(record).to receive(:send_patch).with(ssl: { method: record.ssl.method, type: record.ssl.type })
+				expect(record.ssl_active?(true)).to be expected_value
+			end
+
+		end
+
+	end
+end

--- a/spec/cloudflare/zone_spec.rb
+++ b/spec/cloudflare/zone_spec.rb
@@ -1,23 +1,25 @@
 
 RSpec.describe Cloudflare::Zones, order: :defined, timeout: 30 do
 	include_context Cloudflare::Zone
-	
-	it "can delete existing domain if exists" do
-		if zone = zones.find_by_name(name)
-			expect(zone.delete).to be_success
+
+	if ENV['CLOUDFLARE_TEST_ZONE_MANAGEMENT'] == 'true'
+		it "can delete existing domain if exists" do
+			if zone = zones.find_by_name(name)
+				expect(zone.delete).to be_success
+			end
+		end
+
+		it "can create a zone" do
+			zone = zones.create(name, account)
+			expect(zone.value).to include(:id)
 		end
 	end
-	
-	it "can create zone" do
-		zone = zones.create(name, account)
-		expect(zone.value).to include(:id)
-	end
-	
+
 	it "can list zones" do
 		matching_zones = zones.select{|zone| zone.name == name}
 		expect(matching_zones).to_not be_empty
 	end
-	
+
 	it "can get zone by name" do
 		found_zone = zones.find_by_name(name)
 		expect(found_zone.name).to be == name

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,16 +7,16 @@ require 'cloudflare/zones'
 
 RSpec.shared_context Cloudflare::Zone do
 	include_context Cloudflare::RSpec::Connection
-	
+
 	let(:job_id) {ENV.fetch('TRAVIS_JOB_ID', 0).to_i}
 	let(:names) {['testing', 'horse', 'cat', 'dog', 'fish', 'dolphin', 'lion', 'tiger']}
-	let(:name) {"#{names[job_id % names.size]}.com"}
-	
+	let(:name) {ENV['CLOUDFLARE_ZONE_NAME'] || "#{names[job_id % names.size]}.com"}
+
 	let(:account) {connection.accounts.first}
 	let(:zones) {connection.zones}
-	
+
 	let(:zone) {@zone = zones.find_by_name(name) || zones.create(name, account)}
-	
+
 	# after do
 	# 	if defined? @zone
 	# 		@zone.delete


### PR DESCRIPTION
This adds support for custom hostnames ([https://api.cloudflare.com/#custom-hostname-for-a-zone-properties](https://api.cloudflare.com/#custom-hostname-for-a-zone-properties)).

Notes:

- This feature is only available for plans that have it enabled
  - The custom metadata is enterprise only and needs to be enabled as well
-  I'm not sure the best approach at testing this since the only account I have to test with is production.  I would typically stub out the requests but wanted to make sure whatever route I go fits in with how the maintainers would like it tested.
- I noticed that when searching for an Account by its id, a Zone object was being returned. As part of the consolidation that I did, it now returns an Account object. I can make it continue to return a Zone if that is preferred though.

We'd like to start using this soon, so let me know if/what changes should be made and how you would prefer to see it tested.