### PR TITLE
Fix purge_cache by specifying a path instead of a `path` parameter

### DIFF
--- a/lib/cloudflare/zones.rb
+++ b/lib/cloudflare/zones.rb
@@ -48,7 +48,8 @@ module Cloudflare
 		}.freeze
 		
 		def purge_cache(parameters = DEFAULT_PURGE_CACHE_PARAMS)
-			Zone.new(@resource.with(path: 'purge_cache', parameters: parameters))
+			Zone.new(@resource.with(path: 'purge_cache')).post(parameters)
+			self
 		end
 		
 		def name

--- a/lib/cloudflare/zones.rb
+++ b/lib/cloudflare/zones.rb
@@ -48,9 +48,7 @@ module Cloudflare
 		}.freeze
 		
 		def purge_cache(parameters = DEFAULT_PURGE_CACHE_PARAMS)
-			message = self.with(path: 'purge_cache').post(parameters)
-			
-			return message.success?
+			Zone.new(@resource.with(path: 'purge_cache', parameters: parameters))
 		end
 		
 		def name


### PR DESCRIPTION
Zone#purge_cache is broken in that it posts to the wrong endpoint `zones/:id?path=purge_cache` instead of `zones/:id/purge_cache`.  Representation#with does not take a `path` argument, which could be the root of the problem.