### PR TITLE
Support bearer token authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,18 @@ Cloudflare.connect(key: key, email: email) do |connection|
 end
 ```
 
+### Using an API Token
+
+```ruby
+require 'cloudflare'
+
+token = 'a_generated_api_token'
+
+Cloudflare.connect(token: token) do |connection|
+    # ...
+end
+```
+
 ## Contributing
 
 1. Fork it

--- a/lib/cloudflare.rb
+++ b/lib/cloudflare.rb
@@ -27,11 +27,11 @@ require_relative 'cloudflare/connection'
 module Cloudflare
 	DEFAULT_ENDPOINT = Async::HTTP::Endpoint.parse('https://api.cloudflare.com/client/v4')
 	
-	def self.connect(endpoint = DEFAULT_ENDPOINT, key: nil, email: nil)
+	def self.connect(endpoint = DEFAULT_ENDPOINT, **auth_info)
 		representation = Connection.for(endpoint)
 		
-		if key
-			representation = representation.authenticated(key, email)
+		if !auth_info.empty?
+			representation = representation.authenticated(**auth_info)
 		end
 		
 		return representation unless block_given?

--- a/lib/cloudflare/connection.rb
+++ b/lib/cloudflare/connection.rb
@@ -28,14 +28,18 @@ require_relative 'user'
 
 module Cloudflare
 	class Connection < Representation
-		def authenticated(key, email = nil)
+		def authenticated(token: nil, key: nil, email: nil)
 			headers = {}
 			
-			if email.nil?
-				headers['X-Auth-User-Service-Key'] = key
-			else
-				headers['X-Auth-Key'] = key
-				headers['X-Auth-Email'] = email
+			if token
+				headers['Authorization'] = "Bearer #{token}"
+			elsif key
+				if email
+					headers['X-Auth-Key'] = key
+					headers['X-Auth-Email'] = email
+				else
+					headers['X-Auth-User-Service-Key'] = key
+				end
 			end
 			
 			self.with(headers: headers)


### PR DESCRIPTION
Cloudflare API now supports a normal bearer token authentication method instead of one using an email + API key pair.

https://blog.cloudflare.com/api-tokens-general-availability/
https://api.cloudflare.com/#getting-started-requests