### PR TITLE
Fix support for Workers KV

### DIFF
--- a/cloudflare.gemspec
+++ b/cloudflare.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
 	
 	spec.required_ruby_version = ">= 2.5"
 	
-	spec.add_dependency "async-rest", "~> 0.10.0"
+	spec.add_dependency "async-rest", "~> 0.12.3"
 	
 	spec.add_development_dependency "async-rspec"
 	spec.add_development_dependency "bundler"

--- a/lib/cloudflare/kv/namespaces.rb
+++ b/lib/cloudflare/kv/namespaces.rb
@@ -5,6 +5,7 @@
 
 require_relative '../paginate'
 require_relative '../representation'
+require_relative 'rest_wrapper'
 
 module Cloudflare
 	module KV
@@ -55,7 +56,8 @@ module Cloudflare
 			private
 
 			def value_representation(name)
-				self.with(Representation, path: "values/#{name}")
+				@representation_class ||= Representation[RESTWrapper]
+				self.with(@representation_class, path: "values/#{name}")
 			end
 		end
 

--- a/lib/cloudflare/kv/rest_wrapper.rb
+++ b/lib/cloudflare/kv/rest_wrapper.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module Cloudflare
+  module KV
+    class RESTWrapper < Async::REST::Wrapper::Generic
+      APPLICATION_OCTET_STREAM = 'application/octet-stream'
+      APPLICATION_JSON = 'application/json'
+			ACCEPT_HEADER = "#{APPLICATION_JSON}, #{APPLICATION_OCTET_STREAM}"
+
+      def prepare_request(payload, headers)
+        headers['accept'] ||= ACCEPT_HEADER
+
+        if payload
+          headers['content-type'] = APPLICATION_OCTET_STREAM
+          ::Protocol::HTTP::Body::Buffered.new([payload.to_s])
+        end
+      end
+
+      def parser_for(response)
+        if response.headers['content-type'].start_with?(APPLICATION_OCTET_STREAM)
+          OctetParser
+        elsif response.headers['content-type'].start_with?(APPLICATION_JSON)
+          JsonParser
+        else
+          Async::REST::Wrapper::Generic::Unsupported
+        end
+      end
+
+      class OctetParser < ::Protocol::HTTP::Body::Wrapper
+        def join
+          super
+        end
+      end
+
+      class JsonParser < ::Protocol::HTTP::Body::Wrapper
+        def join
+          JSON.parse(super, symbolize_names: true)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description

Fixes https://github.com/socketry/cloudflare/issues/63

Makes the Workers KV tests pass by handling both binary and JSON payloads. Handling both requires a new `Async::REST::Wrapper` which dispatches to different parsers based on the content-type of the response.

Doing this is predicated on this upstream PR to async-rest, though: https://github.com/socketry/async-rest/pull/7 (hence a version bump in the dependencies to a currently non-existent version of async-rest)