### PR TITLE
origin certificates setup and back-end CIDRs list; NO SPECS

### DIFF
--- a/lib/cloudflare/certificates.rb
+++ b/lib/cloudflare/certificates.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require_relative "representation"
+require_relative "paginate"
+
+module Cloudflare
+	class Certificate < Representation
+		def certificate
+			result[:certificate]
+		end
+	end
+	
+	class Certificates < Representation
+		include Paginate
+		
+		def representation
+			Certificate
+		end
+		
+		def create(csr_pem, hostnames, request_type = "origin-rsa", requested_validity = 5475)
+			represent_message(self.post({
+				csr: csr_pem,
+				request_type: request_type,
+				hostnames: hostnames,
+				requested_validity: requested_validity
+			}))
+		end
+	end
+end

--- a/lib/cloudflare/connection.rb
+++ b/lib/cloudflare/connection.rb
@@ -12,9 +12,11 @@
 
 require "async/rest/resource"
 
+require_relative "ips"
 require_relative "zones"
 require_relative "accounts"
 require_relative "user"
+require_relative "certificates"
 
 module Cloudflare
 	class Connection < Async::REST::Resource
@@ -37,6 +39,10 @@ module Cloudflare
 			self.with(headers: headers)
 		end
 		
+		def cidrs(ipv: nil)
+			IPs.new(self.with(path: "ips")).cidrs(ipv: ipv)
+		end
+		
 		def zones
 			Zones.new(self.with(path: "zones/"))
 		end
@@ -47,6 +53,10 @@ module Cloudflare
 		
 		def user
 			User.new(self.with(path: "user"))
+		end
+		
+		def certificates
+			Certificates.new(self.with(path: "certificates"))
 		end
 	end
 end

--- a/lib/cloudflare/ips.rb
+++ b/lib/cloudflare/ips.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require_relative "representation"
+
+module Cloudflare
+	class IPs < Representation
+		def cidrs(ipv: nil)
+			if ipv
+				result[:"ipv#{ipv}_cidrs"]
+			else
+				result[:ipv4_cidrs].to_a + result[:ipv6_cidrs].to_a
+			end
+		end
+	end
+end


### PR DESCRIPTION
## Description

Support for:
- origin certificates (securing connection from cloudflare to the origin server)
- back-end CIDRs (restricting the origin server's access to cloudflare back end only)
- 
### Types of Changes

- New feature.

### Testing

- [ ] I added tests for my changes.
  - and I'd like to add tests, but couldn't figure the test setup, so this is a draft PR
    - I usually have `bin/test` that runs the suite in a _dockerised_ environment
- [x] I tested my changes in production.
  - and it worked perfectly

