### PR TITLE
Fixes socketry/cloudflare#72

### DIFF
--- a/lib/cloudflare/dns.rb
+++ b/lib/cloudflare/dns.rb
@@ -34,13 +34,13 @@ module Cloudflare
 				@record = record || get.result
 			end
 
-			def update_content(content, **options)
-				response = put(
+			def update_content(content, options)
+				params = {
 					type: @record[:type],
 					name: @record[:name],
-					content: content,
-					**options
-				)
+					content: content
+				}.merge(options)
+				response = put(params)
 
 				@value = response.result
 			end
@@ -74,9 +74,10 @@ module Cloudflare
 			end
 
 			TTL_AUTO = 1
-			
-			def create(type, name, content, **options)
-				represent_message(self.post(type: type, name: name, content: content, **options))
+
+			def create(type, name, content, options)
+				params = {type: type, name: name, content: content}.merge(options)
+				represent_message(self.post(params))
 			end
 
 			def find_by_name(name)

--- a/lib/cloudflare/dns.rb
+++ b/lib/cloudflare/dns.rb
@@ -76,7 +76,11 @@ module Cloudflare
 			TTL_AUTO = 1
 
 			def create(type, name, content, options)
-				params = {type: type, name: name, content: content}.merge(options)
+				params = {
+					type: type,
+					name: name,
+					content: content
+				}.merge(options)
 				represent_message(self.post(params))
 			end
 


### PR DESCRIPTION
## Description
The PR is meant to remove deprecated style of argument in DNS Record to be compatible with ruby 3.0. 
The fix is running in production as a local gem in our projet and it fixed the issue. 
Other features of the gem might still be broken (or not, to be checked) as I only solved DNS record to fix our issue.


### Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

### Testing

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I tested my changes locally.
- [x] I tested my changes in staging.
- [x] I tested my changes in production.
