### PR TITLE
Add R2 basic support

### DIFF
--- a/lib/cloudflare/accounts.rb
+++ b/lib/cloudflare/accounts.rb
@@ -9,6 +9,7 @@ require_relative "representation"
 require_relative "paginate"
 require_relative "kv/namespaces"
 require_relative "r2/buckets"
+require_relative "tokens"
 
 module Cloudflare
 	class Account < Representation
@@ -22,6 +23,10 @@ module Cloudflare
 
 		def r2_buckets
 			self.with(R2::Buckets, path: "r2/buckets")
+		end
+
+		def tokens
+			self.with(Tokens, path: "tokens")
 		end
 	end
 

--- a/lib/cloudflare/accounts.rb
+++ b/lib/cloudflare/accounts.rb
@@ -3,10 +3,12 @@
 # Released under the MIT License.
 # Copyright, 2018-2024, by Samuel Williams.
 # Copyright, 2019, by Rob Widmer.
+# Copyright, 2025, by Ivan Vergés.
 
 require_relative "representation"
 require_relative "paginate"
 require_relative "kv/namespaces"
+require_relative "r2/buckets"
 
 module Cloudflare
 	class Account < Representation
@@ -16,6 +18,10 @@ module Cloudflare
 
 		def kv_namespaces
 			self.with(KV::Namespaces, path: "storage/kv/namespaces")
+		end
+
+		def r2_buckets
+			self.with(R2::Buckets, path: "r2/buckets")
 		end
 	end
 

--- a/lib/cloudflare/r2/buckets.rb
+++ b/lib/cloudflare/r2/buckets.rb
@@ -26,12 +26,19 @@ module Cloudflare
 			end
 
 			def create_cors(**options)
-				self.class.put(@resource.with(path: "#{name}/cors"), options) do |resource, response|
+				payload = { bucket_name: name, **options}
+				self.class.put(@resource.with(path: "#{name}/cors"), payload) do |resource, response|
 					if response.success?
 						cors
 					else
 						raise RequestError.new(resource, response.read)
 					end
+				end
+			end
+
+			def delete
+				self.class.delete(@resource.with(path: name)) do |resource, response|
+					response.success?
 				end
 			end
 		end

--- a/lib/cloudflare/r2/buckets.rb
+++ b/lib/cloudflare/r2/buckets.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2025, by Ivan Vergés.
+
+require_relative "../paginate"
+require_relative "../representation"
+require_relative "domains"
+require_relative "cors"
+
+module Cloudflare
+	module R2
+		class Bucket < Representation
+			include Async::REST::Representation::Mutable
+
+			def name
+				result[:name]
+			end
+
+			def domains
+				self.with(Domains, path: "#{name}/domains/custom")
+			end
+
+			def cors
+				self.with(Cors, path: "#{name}/cors")
+			end
+
+			def create_cors(**options)
+				self.class.put(@resource.with(path: "#{name}/cors"), options) do |resource, response|
+					if response.success?
+						cors
+					else
+						raise RequestError.new(resource, response.read)
+					end
+				end
+			end
+		end
+
+		class Buckets < Representation
+			include Paginate
+
+			def representation
+				Bucket
+			end
+
+			def result
+				value[:result][:buckets]
+			end
+
+			def create(name, **options)
+				payload = {name: name, **options}
+				self.class.post(@resource, payload) do |resource, response|
+					value = response.read
+
+					Bucket.new(resource, value: value, metadata: response.headers)
+				end
+			end
+
+			def find_by_name(name)
+				each.find {|bucket| bucket.name == name }
+			end
+		end
+	end
+end

--- a/lib/cloudflare/r2/cors.rb
+++ b/lib/cloudflare/r2/cors.rb
@@ -9,8 +9,6 @@ require_relative "../representation"
 module Cloudflare
 	module R2
 		class Cors < Representation
-			include Async::REST::Representation::Mutable
-
 			def rules
 				result[:rules]
 			end

--- a/lib/cloudflare/r2/cors.rb
+++ b/lib/cloudflare/r2/cors.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2025, by Ivan Vergés.
+
+require_relative "../paginate"
+require_relative "../representation"
+
+module Cloudflare
+	module R2
+		class Cors < Representation
+			include Async::REST::Representation::Mutable
+
+			def rules
+				result[:rules]
+			end
+		end
+	end
+end

--- a/lib/cloudflare/r2/domains.rb
+++ b/lib/cloudflare/r2/domains.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2025, by Ivan Vergés.
+
+require_relative "../paginate"
+require_relative "../representation"
+
+module Cloudflare
+	module R2
+		class Domain < Representation
+			include Async::REST::Representation::Mutable
+
+			def name
+				result[:domain]
+			end
+		end
+
+		class Domains < Representation
+			include Paginate
+
+			def representation
+				R2::Domain
+			end
+
+			def result
+				value[:result][:domains]
+			end
+
+			def attach(domain, **options)
+				payload = {domain:, **options}
+
+				self.class.post(@resource, payload) do |resource, response|
+					value = response.read
+
+					Domain.new(resource, value: value, metadata: response.headers)
+				end
+			end
+
+			def find_by_name(name)
+				each.find {|domain| domain.name == name }
+			end
+		end
+	end
+end

--- a/lib/cloudflare/r2/domains.rb
+++ b/lib/cloudflare/r2/domains.rb
@@ -9,8 +9,6 @@ require_relative "../representation"
 module Cloudflare
 	module R2
 		class Domain < Representation
-			include Async::REST::Representation::Mutable
-
 			def name
 				result[:domain]
 			end

--- a/lib/cloudflare/tokens.rb
+++ b/lib/cloudflare/tokens.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2025, by Ivan Vergés.
+
+require "digest"
+require_relative "paginate"
+require_relative "representation"
+
+module Cloudflare
+  class Token < Representation
+    include Async::REST::Representation::Mutable
+
+    def name
+      result[:name]
+    end
+
+    def id
+      result[:id]
+    end
+
+    def secret
+      Digest::SHA2.hexdigest(result[:value])
+    end
+
+    def delete
+      self.class.delete(@resource.with(path: name)) do |resource, response|
+        response.success?
+      end
+    end
+  end
+
+  class Tokens < Representation
+    include Paginate
+
+    def representation
+      Token
+    end
+
+    def result
+      value[:result]
+    end
+
+    def create(name, **options)
+      payload = {name: name, **options}
+      self.class.post(@resource, payload) do |resource, response|
+        value = response.read
+
+        Token.new(resource, value: value, metadata: response.headers)
+      end
+    end
+
+    def find_by_name(name)
+      each.find {|token| token.name == name }
+    end
+  end
+end

--- a/lib/cloudflare/user.rb
+++ b/lib/cloudflare/user.rb
@@ -5,6 +5,7 @@
 # Copyright, 2018, by Leonhardt Wille.
 
 require_relative "representation"
+require_relative "tokens"
 
 module Cloudflare
 	class User < Representation
@@ -14,6 +15,10 @@ module Cloudflare
 		
 		def email
 			result[:email]
+		end
+
+		def tokens
+			self.with(Tokens, path: "tokens")
 		end
 	end
 end

--- a/lib/cloudflare/zones.rb
+++ b/lib/cloudflare/zones.rb
@@ -59,6 +59,10 @@ module Cloudflare
 		def name
 			result[:name]
 		end
+
+		def id
+			result[:id]
+		end
 		
 		alias to_s name
 	end

--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,46 @@ Cloudflare.connect(key: key, email: email) do |connection|
 	
 	# Block an ip:
 	rule = zone.firewall_rules.set('block', '1.2.3.4', notes: "ssh dictionary attack")
+
+	# Get an account
+	connection.accounts.find_by_id(ENV["CLOUDFLARE_ACCOUNT_ID"]) do |account|
+		# Find a R2 bucket
+		bucket = account.r2_buckets.find_by_name("a-s3-compatible-bucket")
+
+		# Create a new bucket
+		bucket = account.r2_buckets.create("another-s3-compatible-bucket")
+
+		# Attaching a public domain to a bucket
+		payload = {
+			"zoneId" => zone.id,
+			"enabled" => true
+		}
+		bucket.domains.attach("bucket.example.com", **payload)
+
+		# Adding a CORS policy to a bucket
+		rules = [
+		{
+			allowed: {
+			origins: ["domain.tld", "anotherdomain.tld"],
+			methods: ["GET", "PUT"],
+			headers: ["*"],
+			},
+			exposeHeaders: [
+			"Origin",
+			"Content-Type",
+			"Content-MD5",
+			"Content-Disposition"
+			],
+			maxAgeSeconds: 3600
+		}
+		]
+		payload = {
+			"account_id" => account.id,
+			"bucket_name" => "a-nice-bucket",
+			"rules" => rules
+		}
+		bucket.create_cors(**payload)
+	end
 end
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -60,7 +60,7 @@ end
 
 ### Using a Bearer Token
 
-You can read more about [bearer tokens here](https://blog.cloudflare.com/api-tokens-general-availability/). This allows you to limit priviledges.
+You can read more about [bearer tokens here](https://blog.cloudflare.com/api-tokens-general-availability/). This allows you to limit privileges.
 
 ``` ruby
 require 'cloudflare'

--- a/test/cloudflare/accounts.rb
+++ b/test/cloudflare/accounts.rb
@@ -36,4 +36,12 @@ describe Cloudflare::Accounts do
 		
 		expect(namespace.resource.reference.path).to be(:end_with?, "/#{account.id}/storage/kv/namespaces")
 	end
+
+	it "can generate a representation for the R2 bucket endpoint" do
+		buckets = connection.accounts.find_by_id(account.id).r2_buckets
+		
+		expect(buckets).to be_a(Cloudflare::R2::Buckets)
+		
+		expect(buckets.resource.reference.path).to be(:end_with?, "/#{account.id}/r2/buckets")
+	end
 end

--- a/test/cloudflare/r2/buckets.rb
+++ b/test/cloudflare/r2/buckets.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2025, by Ivan Vergés.
+
+require "cloudflare/r2/buckets"
+require "cloudflare/a_connection"
+
+describe Cloudflare::R2::Buckets do
+	include_context Cloudflare::AConnection
+
+	let(:temporary_zone_name) { "#{SecureRandom.hex(8)}-testing.com" }
+	let(:bucket_name) { "test-bucket-#{SecureRandom.hex(4)}" }
+	let(:bucket) { account.r2_buckets.create(bucket_name) }
+
+	after do
+		@bucket&.delete
+	end
+
+	it "can create a bucket" do
+		expect(bucket).to be_a(Cloudflare::R2::Bucket)
+		expect(bucket.name).to be == bucket_name
+
+		fetched_bucket = account.r2_buckets.find_by_name(bucket_name)
+		expect(fetched_bucket).to have_attributes(
+						name: be == bucket.name
+						)
+	end
+
+	it "can attach a domain to a bucket" do
+		temporary_zone = zones.create(temporary_zone_name, account)
+		payload = { zoneId: temporary_zone.id, enabled: true }
+		
+		# this is a workaround as the domain must have the DNS records set up correctly for this to work
+		expect do
+			bucket.domains.attach("subdomain.#{temporary_zone.name}", **payload)
+		end.to raise_exception(Cloudflare::RequestError, message: be =~ /The specified zone id is not valid/)
+
+		temporary_zone.delete
+	end
+
+	it "can create a CORS policy" do
+		rules = [
+		{
+			allowed: {
+				methods: ["GET", "PUT"],
+				headers: ["*"],
+				origins: ["https://example.com"]
+			},
+			exposeHeaders: [
+				"Origin",
+			],
+			maxAgeSeconds: 3600
+		}
+		]
+		cors = bucket.create_cors(account_id: account.id, rules: rules)
+		expect(cors).to be_a(Cloudflare::R2::Cors)
+	end
+end


### PR DESCRIPTION
This PR adds support for some actions regarding the R2 api in Cloudflare.

Allows to:
- [x] List buckets in an account
- [x] Create buckets in an account
- [x] Create CORS policy for a bucket
- [x] Attach a domain to a bucket (for public serving files)

Examples:

Listing available buckets:
```ruby
connection ||= Async { Cloudflare.connect(token: ENV["CLOUDFLARE_TOKEN"]) }.wait
account ||= Async { connection.accounts.find_by_id(account_id: ENV["CLOUDFLARE_ACCOUNT_ID"]) }.wait
puts Async { account.r2_buckets.result }.wait
```

Obtaining a specific bucket
```ruby
puts Async { account.r2_buckets.find_by_name("a-nice-bucket") .inspect }.wait
```

Creating a bucket:
```ruby
Async { account.r2_buckets.create("a-new-bucket")  }.wait
```

Attaching a domain to a bucket:
```ruby
payload = {
  "cf-r2-jurisdiction" => "eu", 
  "zoneId" => ENV["CLOUDFLARE_ZONE_ID"],
  "enabled" => true
}
domain = Async { bucket.domains.attach(domain_name, **payload) }.wait
```

Creating a cors policy:
```ruby
rules = [
  {
    allowed: {
      origins: ["domain.tld", "anotherdomain.tld"],
      methods: ["GET", "PUT"],
      headers: ["*"],
    },
    exposeHeaders: [
      "Origin",
      "Content-Type",
      "Content-MD5",
      "Content-Disposition"
    ],
    maxAgeSeconds: 3600
  }
]
payload = {
  "cf-r2-jurisdiction" => "eu", 
  "account_id" => ENV["CLOUDFLARE_ACCOUNT_ID"],
  "bucket_name" => "a-nice-bucket",
  "rules" => rules
}
Async { bucket.create_cors(**payload) }.wait
```

Obtaining the current CORS (the API throws an exception if there's none yet):
```ruby
cors = Async do
  begin
    bucket.cors.result
  rescue Cloudflare::RequestError
    nil
  end
end.wait

puts cors
```

## Types of Changes

- New feature.

## Contribution

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
