### PR TITLE
Fix: typo in CustomHostname#patch

### DIFF
--- a/lib/cloudflare/custom_hostnames.rb
+++ b/lib/cloudflare/custom_hostnames.rb
@@ -62,7 +62,7 @@ module Cloudflare
 			self.class.patch(@resource, payload) do |resource, response|
 				value = response.read
 				
-				if value[:sucess]
+				if value[:success]
 					@ssl = nil
 					@value = value
 				else


### PR DESCRIPTION
## What changes are being made? What problem are you solving?

Fixed a typo in the `lib/cloudflare/custom_hostnames.rb` file where `:success` was misspelled as `:sucess` in the response handling logic.

## What feature/bug is being fixed here?

**Bug fix**: The typo in line 65 was causing the success check to fail, which would prevent proper handling of successful API responses in the `patch` method of the `CustomHostname` class. This lead to unnecessary `RequestError` exceptions being raised even when the API call was successful.

## Types of Changes

- Bug fix.

## Contribution

- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).