### PR TITLE
stop exploding when response is a string

### DIFF
--- a/lib/cloudflare/representation.rb
+++ b/lib/cloudflare/representation.rb
@@ -13,73 +13,73 @@ require "async/rest/wrapper/json"
 module Cloudflare
 	class RequestError < StandardError
 		def initialize(request, value)
-			if error = value[:error]
+			if value.is_a?(Hash) && error = value[:error]
 				super("#{request}: #{error}")
-			elsif errors = value[:errors]
+			elsif value.is_a?(Hash) && errors = value[:errors]
 				super("#{request}: #{errors.map{|attributes| attributes[:message]}.join(', ')}")
 			else
 				super("#{request}: #{value.inspect}")
 			end
-			
+
 			@value = value
 		end
-		
+
 		attr :value
 	end
-	
+
 	class Wrapper < Async::REST::Wrapper::JSON
 		def process_response(request, response)
 			super
-			
+
 			if response.failure?
 				raise RequestError.new(request, response.read)
 			end
 		end
 	end
-	
+
 	class Representation < Async::REST::Representation
 		WRAPPER = Wrapper.new
-		
+
 		def representation
 			Representation
 		end
-		
+
 		def represent(metadata, attributes)
 			resource = @resource.with(path: attributes[:id])
-			
+
 			representation.new(resource, metadata: metadata, value: {
 				success: true, result: attributes
 			})
 		end
-		
+
 		def represent_message(message)
 			represent(message.headers, message.result)
 		end
-		
+
 		def result
 			value[:result]
 		end
-		
+
 		def to_hash
 			result
 		end
-		
+
 		def to_id
 			{id: result[:id]}
 		end
-		
+
 		def results
 			Array(result)
 		end
-		
+
 		def errors
 			value[:errors]
 		end
-		
+
 		def messages
 			value[:messages]
 		end
-		
+
 		def success?
 			value[:success]
 		end


### PR DESCRIPTION
Sometimes the value returned by Cloudflare isn't a hash. In those cases, this handler would previously just raise by trying to index into a string with a symbol key. My app no longer crashes with this patch, which I have been running for about 6 months now.

## Types of Changes

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
